### PR TITLE
Exit the completion process on EOF

### DIFF
--- a/lib/completion.py
+++ b/lib/completion.py
@@ -326,8 +326,6 @@ class JediCompletion(object):
     def _process_request(self, request):
         """Accept serialized request from Atom and write response.
         """
-        if not request:
-          return
         request = self._deserialize(request)
 
         self._set_request_config(request.get('config', {}))
@@ -371,7 +369,12 @@ class JediCompletion(object):
         while True:
             try:
                 sys.stdout, sys.stderr = self.devnull, self.devnull
-                self._process_request(self._input.readline())
+
+                request = self._input.readline()
+                if not request:
+                    return
+
+                self._process_request(request)
             except Exception:
                 sys.stderr = self.stderr
                 sys.stderr.write(traceback.format_exc() + '\n')


### PR DESCRIPTION
The real problem is that [`BufferedProcess.kill`](https://github.com/atom/atom/blob/df1d1c92c4b04938aeba335748a7b12bd87c3963/src/buffered-process.js#L234-L243) is *asynchronous* [on Windows](https://github.com/atom/atom/blob/df1d1c92c4b04938aeba335748a7b12bd87c3963/src/buffered-process.js#L164-L206) and Atom exits before it gets a chance to complete. So the process is left alive, and it ignores EOF and just keeps trying to read in an infinite loop.

Fixes https://github.com/autocomplete-python/autocomplete-python/issues/310