### PR TITLE
Don't consider directories as valid interpreter executables

### DIFF
--- a/lib/interpreters-lookup.coffee
+++ b/lib/interpreters-lookup.coffee
@@ -38,6 +38,9 @@ module.exports =
 
   isBinary: (filePath) ->
     try
+      if not fs.statSync(filePath).isFile()
+        return false
+
       fs.accessSync filePath, fs.X_OK
       return true
     catch


### PR DESCRIPTION
Otherwise if you have a directory named "python" in `PATH`, it might consider it as valid interpreter executable and get stuck in an infinite loop (The infinite loop on interpreter spawn failure is obviously a separate bug).